### PR TITLE
Fix the arn output to be a scalar value instead of a list

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,26 @@ locals {
   has_secrets = length(local.all_secrets) > 0
 }
 
+/**
+ * We want to have a plan appear anytime the definition will be updated on a
+ * run of `terraform plan`.
+ *
+ * As the primary purpose of this module is to create json output and not create a resource,
+ * the bulk of the work does not show up in plans. So we use a dummy resource here to make changes
+ * to the json document appear in the plan.
+ */
+resource null_resource dummy {
+  # Changes to any instance of the cluster requires re-provisioning
+  triggers = {
+    container_definition = module.definition.json
+    what_is_this   = <<EOF
+    You may be wondering why you're seeing some resource named `null_resource.dummy` with a plan
+    after updating this module. Well no fear, this is just done to let you know that you need
+    to run an `atlantis apply` on the CI system to change the output of this module.
+    EOF
+  }
+}
+
 resource "aws_ssm_parameter" "params" {
   for_each = var.secret_environment
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,8 +9,8 @@ output json_map {
 }
 
 output secrets_policy_arn {
-  value       = aws_iam_policy.secret_access_policy.*.arn
-  description = "Amazon Resource Name of an IAM Policy granting access to read the SSM Parameters created in this module"
+  value       = local.has_secrets ? aws_iam_policy.secret_access_policy[0].arn : ""
+  description = "Amazon Resource Name of an IAM Policy granting access to read the SSM Parameters created in this module. Empty if no secrets are present"
 }
 
 output container_name {


### PR DESCRIPTION
Also added a dummy null_resource object. This is so that `terraform plan` output will show the json changes, which were previously hidden because the json is not a "resource" in terraform