### PR TITLE
Fix issue when number of secrets changes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ locals {
     ceil(length(local.ssm_arns) / var.secret_policy_chunks)
   )
 
-  has_secrets = length(local.ssm_arns) > 0
+  has_secrets = length(var.secret_environment) + length(var.log_secrets) > 0
 }
 
 /**


### PR DESCRIPTION
When updating the number of `secret_environment` or `log_secrets`, it was possible to hit the following error:

```
Error: Invalid count argument

  on main.tf line 81, in resource "aws_iam_policy" "secret_access_policy":
  81:   count = local.has_secrets ? var.secret_policy_chunks : 0

The "count" value depends on resource attributes that cannot be determined
until apply, so Terraform cannot predict how many instances will be created.
To work around this, use the -target argument to first apply only the
resources that the count depends on.
```

This was because the `local.has_secrets` depended on the outputs of other resources.

This PR attempts to fix the issue by making `local.has_secrets` be determined directly from vars, not using any resource outputs