### PR TITLE
Remove linux parameters unsupported by Fargate

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -238,8 +238,5 @@ variable "linux_parameters" {
     initProcessEnabled = bool
   })
   description = "Linux-specific modifications that are applied to the container, such as Linux kernel capabilities."
-  default = {
-    capabilities       = {}
-    initProcessEnabled = false
-  }
+  default     = {}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -235,21 +235,11 @@ variable "linux_parameters" {
       add  = list(string)
       drop = list(string)
     })
-    devices = list(object({
-      containerPath = string
-      hostPath      = string
-      permissions   = list(string)
-    }))
     initProcessEnabled = bool
-    maxSwap            = number
-    sharedMemorySize   = number
-    swappiness         = number
-    tmpfs = list(object({
-      containerPath = string
-      mountOptions  = list(string)
-      size          = number
-    }))
   })
   description = "Linux-specific modifications that are applied to the container, such as Linux kernel capabilities."
-  default     = null
+  default = {
+    capabilities       = {}
+    initProcessEnabled = false
+  }
 }


### PR DESCRIPTION
# Pull Request

Some of the linux_parameters options are not supported on Fargate. I overlooked this initially when adding the `linux_parameters` variable. Also adds in a default value when `linux_parameters` is not provided

## Related Github Issues

- _[none]_

## Description

TODO

## Security Implications

- _[none]_

## System Availability

- _[none]_
