### PR TITLE
Change linux_parameters default value

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -238,5 +238,11 @@ variable "linux_parameters" {
     initProcessEnabled = bool
   })
   description = "Linux-specific modifications that are applied to the container, such as Linux kernel capabilities."
-  default     = {}
+  default = {
+    capabilities = {
+      add  = []
+      drop = []
+    }
+    initProcessEnabled = false
+  }
 }


### PR DESCRIPTION
# Pull Request

Terraform objects must contain all of their required keys. The default `linux_parameters` object cannot be an empty object.

## Related Github Issues

- _[none]_

## Description

TODO

## Security Implications

- _[none]_

## System Availability

- _[none]_
