### PR TITLE
Add all linux_parameters options

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -126,7 +126,13 @@ module "definition" {
     }
   ])
 
-  linux_parameters = var.linux_parameters
+  linux_parameters = merge(var.linux_parameters, {
+    devices = []
+    maxSwap = 0
+    sharedMemorySize = 64
+    swappiness = 60
+    tmpfs = []
+  })
 }
 
 resource "aws_cloudwatch_log_group" "log_group" {


### PR DESCRIPTION
# Pull Request

Add in default values for all `linux_parameters` options, even those that aren't supported by Fargate.

## Related Github Issues

- _[none]_

## Description

TODO

## Security Implications

- _[none]_

## System Availability

- _[none]_
