### PR TITLE
Add docker security options

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -127,6 +127,7 @@ module "definition" {
   ])
 
   linux_parameters = var.linux_parameters
+  docker_security_options = var.docker_security_options
 }
 
 resource "aws_cloudwatch_log_group" "log_group" {

--- a/variables.tf
+++ b/variables.tf
@@ -253,3 +253,9 @@ variable "linux_parameters" {
   description = "Linux-specific modifications that are applied to the container, such as Linux kernel capabilities. For more details, see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_LinuxParameters.html"
   default     = null
 }
+
+variable "docker_security_options" {
+  type        = list(string)
+  description = "A list of strings to provide custom labels for SELinux and AppArmor multi-level security systems."
+  default     = null
+}


### PR DESCRIPTION
# Pull Request

## Related Github Issues

- _[none]_

## Description

We sometimes need to configure the docker security options. In our case, it's needed for configuring the datadog agent to enable network perf monitoring: https://docs.datadoghq.com/network_performance_monitoring/installation/?tab=docker

## Security Implications

- _[none]_

## System Availability

- _[none]_
