### PR TITLE
Update Terraform AWS provider version.

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,8 +2,8 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
-      version = ">= 3.19.0"
+      version = ">= 5.0.0"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.3"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -5,5 +5,5 @@ terraform {
       version = ">= 5.0.0"
     }
   }
-  required_version = ">= 1.3"
+  required_version = ">= 1.0.0"
 }


### PR DESCRIPTION
Confirmed this works with our ECS tasks.

# Pull Request

## Related Github Issues

- _[none]_

## Description

Upgrade the AWS Provider to allow for AWS SSO credentials usage.

## Security Implications

- _[none]_

## System Availability

- _[none]_
